### PR TITLE
fix(BeltBot): Make request format more tolerant.

### DIFF
--- a/bot/beltbot.py
+++ b/bot/beltbot.py
@@ -61,7 +61,7 @@ from bot.constants import ALL_BELTS, HUMAN_READABLE_BELTS, MY_NAME
 
 
 PUNCTUATION = set(punctuation)
-BELT_REQUEST_REGEX = re.compile("^(?P<belt>{belts})(?P<reason>.*)".format(belts="|".join(map(re.escape, ALL_BELTS))), re.DOTALL | re.IGNORECASE)
+BELT_REQUEST_REGEX = re.compile("(?P<belt>{belts})(?P<reason>.*)".format(belts="|".join(map(re.escape, ALL_BELTS))), re.DOTALL | re.IGNORECASE)
 
 
 _request_help = "Include your username in the format `/u/username_here` anywhere in the message body to be flaired on reddit!"


### PR DESCRIPTION
The caret here forces the request to be like "LPUBeltBot request blue whatever else" but people will often throw in extra words. Removing the caret allows this to still match as long as it finds a color. So something like "LPUBeltBot request for blue belt and also you can sync /u/Whatever" will still work requiring less mod attention in the channel.